### PR TITLE
fix(get): use event ETag instead of calendar ETag for single-event GET

### DIFF
--- a/routes/calendar/calendar/get.js
+++ b/routes/calendar/calendar/get.js
@@ -88,13 +88,13 @@ module.exports = function (options) {
       ctx.status = 200;
       ctx.remove('DAV');
       ctx.set('Content-Type', 'text/calendar; charset=utf-8');
-      ctx.set('ETag', options.data.getETag(ctx, calendar));
+      ctx.set('ETag', options.data.getETag(ctx, event));
       return ics;
     }
 
     const responseObj = response(ctx.url, status[200], [
       {
-        'D:getetag': options.data.getETag(ctx, calendar)
+        'D:getetag': options.data.getETag(ctx, event)
       },
       {
         'CAL:calendar-data': encodeXMLEntities(ics)


### PR DESCRIPTION
## Summary

The GET handler for individual calendar events passes `calendar` to `getETag()` instead of `event`, causing the returned ETag to be based on `calendar.updated_at` rather than `event.updated_at`.

Since the PUT handler's `If-Match` check (`put.js:86`) correctly computes the ETag from the event object, any client that obtains an ETag via GET will always receive a **412 Precondition Failed** when attempting a conditional update — the ETags can never match.

## Root Cause

In `routes/calendar/calendar/get.js`, lines 91 and 97 (single-event GET paths):

```javascript
// Before (bug)
ctx.set('ETag', options.data.getETag(ctx, calendar));

// After (fix)
ctx.set('ETag', options.data.getETag(ctx, event));
```

This bug has existed since **v8.0.0** when ETags were first added to the GET handler — the original code includes a TODO comment acknowledging the uncertainty:

```javascript
// TODO: should E-Tag here be of calendar or event?
'D:getetag': options.data.getETag(ctx, calendar)
```

The HTTP header ETag (`ctx.set('ETag', ...)`) was added in **v8.2.9**, copying the same `calendar` argument.

## Impact

- **PROPFIND/REPORT ETags** are **not affected** — `tags.js:112` correctly passes `event`
- **GET ETags** (both HTTP header and XML body) are affected
- CalDAV clients that use GET-derived ETags for conditional PUT will always fail
- Violates RFC 7232 §2.3 (ETags must be consistent across methods)

## What's NOT changed

Lines 51 and 58 (whole-calendar GET) correctly keep `calendar` since those return the calendar-level resource, not an individual event.

## Verified against production

Tested against `caldav.forwardemail.net` — confirmed that PUT, PROPFIND, multiget, and calendar-query all return the same (correct) ETag, while GET returns a different (wrong) one:

| Source | ETag | Correct? |
|---|---|---|
| PUT response | `"18-pyxvfywc6xV..."` | ✓ |
| PROPFIND XML | `"18-pyxvfywc6xV..."` | ✓ |
| calendar-multiget | `"18-pyxvfywc6xV..."` | ✓ |
| calendar-query | `"18-pyxvfywc6xV..."` | ✓ |
| **GET response** | `"18-F8KY8wtCyo..."` | **✗ — different** |

## Test plan

- [ ] `PUT` create event, capture ETag from response
- [ ] `GET` same event, verify ETag header matches PUT response
- [ ] `PUT` update with GET-derived ETag + `If-Match` → should return 204 (not 412)
- [ ] PROPFIND and REPORT ETags remain unchanged